### PR TITLE
Link to threads library

### DIFF
--- a/cpp20/CMakeLists.txt
+++ b/cpp20/CMakeLists.txt
@@ -1,4 +1,5 @@
 set_property(DIRECTORY PROPERTY LABELS 20)
+find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_STANDARD 20)
 
@@ -56,7 +57,7 @@ have_ranges_find
 foreach(t IN LISTS cpp20features)
   if(have_${t})
     add_executable(${t} ${t}.cpp)
-
+    target_link_libraries(${t} PRIVATE Threads::Threads)
     add_test(NAME ${t} COMMAND ${t})
   endif()
 endforeach()

--- a/cpp23/CMakeLists.txt
+++ b/cpp23/CMakeLists.txt
@@ -1,4 +1,5 @@
 set_property(DIRECTORY PROPERTY LABELS 23)
+find_package(Threads REQUIRED)
 
 set(CMAKE_CXX_STANDARD 23)
 
@@ -64,6 +65,7 @@ endblock()
 foreach(t IN LISTS cpp23features)
   if(have_${t})
     add_executable(${t} ${t}.cpp)
+    target_link_libraries(${t} PRIVATE Threads::Threads)
 
     if(${t} STREQUAL "unreachable")
       add_test(NAME unreachable


### PR DESCRIPTION
When building the test with `clang-20` and `libc++` enabled, I got linker errors due to missing symbols from pthread.
It turns out, some of the examples require linking with -lpthread on Linux.

For simplicity, I link all tests to pthreads. It doesn't really hurt those who don't need it.